### PR TITLE
Fix Sentry Pillar dependancy on Elysium.

### DIFF
--- a/java/me/dawars/CraftingPillars/api/sentry/GameProfileCompatibility.java
+++ b/java/me/dawars/CraftingPillars/api/sentry/GameProfileCompatibility.java
@@ -1,6 +1,6 @@
 package me.dawars.CraftingPillars.api.sentry;
 
-import hu.hundevelopers.elysium.Elysium;
+import cpw.mods.fml.common.Loader;
 
 import java.lang.reflect.Constructor;
 import java.util.UUID;
@@ -8,10 +8,9 @@ import java.util.UUID;
 import com.mojang.authlib.GameProfile;
 
 public class GameProfileCompatibility {
-//Unused
 	public static Object get(String id, String name) {
 
-		if (!Elysium.proxy.getMinecraftVersion().equals("1.7.2")) {
+		if (!Loader.instance().getMinecraftModContainer().getVersion().equals("1.7.2")) {
 			try {
 				Class<?> fake = Class.forName("com.mojang.authlib.GameProfile");
 				Constructor<?> constructor = fake.getConstructor(UUID.class, String.class);
@@ -21,7 +20,8 @@ public class GameProfileCompatibility {
 				return null;
 			}
 		} else {
-			return new GameProfile("sentry", "Sentry Pillar");
+			//return new GameProfile("sentry", "Sentry Pillar");
+			return new GameProfile(null, "Sentry Pillar");
 		}
 	}
 }


### PR DESCRIPTION
Fixes dependency on Elysium for Sentry Pillars. Probably breaks 1.7.2 compatibility, but I don't think the dependancy bug exists in 1.7.2.
